### PR TITLE
Fixed $null check for consistency and variable "$sudoOffset" typo. Un…

### DIFF
--- a/scripts/sudo.ps1
+++ b/scripts/sudo.ps1
@@ -26,7 +26,7 @@ BEGIN {
 	}
 
 	$thisPowerShell = $psProcess.MainModule.FileName
-	if ($thisPowerShell -eq $null) {
+	if ($null -eq $thisPowerShell) {
 		throw "Cannot determine path to '$psProcess'"
 	}
 
@@ -54,10 +54,9 @@ END {
 		return
 	}
 
-	$iam = $MI.MyCommand.ToString()
 	$cmdLine = $MI.Line
 	$sudoOffset = $cmdLine.IndexOf($MI.InvocationName)
-	$cmdLineWithoutScript = $cmdLine.SubString($sudoOffet + 5)
+	$cmdLineWithoutScript = $cmdLine.SubString($sudoOffset + 5)
 	$cmdLineAst = [System.Management.Automation.Language.Parser]::ParseInput($cmdLineWithoutScript, [ref]$null, [ref]$null)
 	$commandAst = $cmdLineAst.Find({$args[0] -is [System.Management.Automation.Language.CommandAst]}, $false)
 	$commandName = $commandAst.GetCommandName()


### PR DESCRIPTION
Fixed $null comparison for consistency and corrected a code typo, but I'm **unsure if it introduces new issues or solves them**.

`$sudoOffet` ➡️ `$sudoOffset`

```
$sudoOffset = $cmdLine.IndexOf($MI.InvocationName)
$cmdLineWithoutScript = $cmdLine.SubString($sudoOffset + 5) # Typo was here
```

Also removed unused line of code `$iam = $MI.MyCommand.ToString()`. This might be used for debugging?