### PR TITLE
Verify the platform as quickly as possible

### DIFF
--- a/scripts/sudo.ps1
+++ b/scripts/sudo.ps1
@@ -3,6 +3,10 @@
 
 # open question - Should -NoProfile be used when invoking PowerShell
 BEGIN {
+	if ([Environment]::OSVersion.Platform -ne "Win32NT") {
+		throw "This script works only on Microsoft Windows"
+	}
+
 	if ($__SUDO_TEST -ne $true) {
 		$SUDOEXE = "sudo.exe"
 	}
@@ -10,10 +14,6 @@ BEGIN {
 		if ($null -eq $SUDOEXE) {
 			throw "variable SUDOEXE has not been set for testing"
 		}
-	}
-
-	if ([Environment]::OSVersion.Platform -ne "Win32NT") {
-		throw "This script works only on Microsoft Windows"
 	}
 
 	if ($null -eq (Get-Command -Type Application -Name "$SUDOEXE" -ErrorAction Ignore)) {


### PR DESCRIPTION
This PR moves the platform check to the beginning of the script, rather than somewhere in the middle.

This prepares for the possibility of adding a GitHub workflow to test behavior on Linux / macOS platforms, to confirm that the script reports that it doesn't support those platforms (rather than checking the `$__SUDO_TEST` and `$SUDOEXE` variables first and potentially reporting an error message for those checks instead).