### PR TITLE
Use `default-features` for future compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ cc = "1.0"
 # To use clap at all, you do need the std feature enabled, so enable that.
 #
 # See: https://docs.rs/clap/latest/clap/_features/index.html
-clap = { version = "4.4.7", default_features = false, features = ["std"] }
+clap = { version = "4.4.7", default-features = false, features = ["std"] }
 embed-manifest = "1.4"
 which = "6.0"
 win_etw_provider = "0.1.8"

--- a/sudo/Cargo.toml
+++ b/sudo/Cargo.toml
@@ -19,7 +19,7 @@ which = { workspace = true }
 
 [dependencies]
 
-clap = { workspace = true, default_features = false, features = ["color", "help", "usage", "error-context"] }
+clap = { workspace = true, default-features = false, features = ["color", "help", "usage", "error-context"] }
 which = { workspace = true }
 windows-registry = { workspace = true }
 


### PR DESCRIPTION
`default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition.

This deals with the build warning when compiled with Rust nightly. 