### PR TITLE
Warn during build if generating resources fails

### DIFF
--- a/sudo/build.rs
+++ b/sudo/build.rs
@@ -93,17 +93,17 @@ fn build_rpc() {
     let cl_path =
         cc::windows_registry::find_tool(target.as_str(), "cl.exe").expect("Failed to find cl.exe");
     // add cl.exe to our path
-    let mut path = std::env::var("PATH").unwrap();
+    let mut path = env::var("PATH").unwrap();
     path.push(';');
     path.push_str(cl_path.path().parent().unwrap().to_str().unwrap());
-    std::env::set_var("PATH", path);
+    env::set_var("PATH", path);
 
     // Great! we've now finally got a path to midl.exe, and cl.exe is on the PATH
 
     // Now we can actually run midl.exe, to compile the IDL file. This will
     // generate a bunch of files in the OUT_DIR which we need to do RPC.
 
-    let mut cmd = std::process::Command::new(midl_path);
+    let mut cmd = Command::new(midl_path);
     cmd.arg("../cpp/rpc/sudo_rpc.idl");
     cmd.arg("/h").arg("sudo_rpc.h");
     cmd.arg("/target").arg("NT100"); // LOAD BEARING: Enables system_handle
@@ -166,7 +166,7 @@ fn build_logging() {
 
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
-    let mut cmd = std::process::Command::new(mc_path);
+    let mut cmd = Command::new(mc_path);
     cmd.arg("-h").arg(&out_dir);
     cmd.arg("-r").arg(&out_dir);
     cmd.arg("../cpp/logging/instrumentation.man");
@@ -233,14 +233,14 @@ fn main() -> io::Result<()> {
         .expect("Failed to generate resources");
 
     // witchcraft to get windows.h from the SDK to be able to be found, for the resource compiler
-    let target = std::env::var("TARGET").unwrap();
+    let target = env::var("TARGET").unwrap();
     if let Some(tool) = cc::windows_registry::find_tool(target.as_str(), "cl.exe") {
         for (key, value) in tool.env() {
-            std::env::set_var(key, value);
+            env::set_var(key, value);
         }
     }
 
-    if std::env::var_os("CARGO_CFG_WINDOWS").is_some() {
+    if env::var_os("CARGO_CFG_WINDOWS").is_some() {
         // TODO:MSFT
         // Re-add the following:
         //     <windowsSettings>

--- a/sudo/build.rs
+++ b/sudo/build.rs
@@ -219,7 +219,7 @@ fn main() -> io::Result<()> {
     // powershell -c .pipelines\convert-resx-to-rc.ps1 .\ no_existy.h res.h no_existy.rc out.rc resource_ids.rs
     // to generate the resources
 
-    Command::new("powershell")
+    let generate_resources_result = Command::new("powershell")
         .arg("-NoProfile")
         .arg("-c")
         .arg("..\\.pipelines\\convert-resx-to-rc.ps1")
@@ -231,6 +231,18 @@ fn main() -> io::Result<()> {
         .arg("resource_ids.rs") // Target file name of the rust resource file, which will be used in code - Example: resource.rs
         .status()
         .expect("Failed to generate resources");
+
+    if !generate_resources_result.success() {
+        println!(
+            "\nFailed to generate resources by executing powershell script: {}.",
+            generate_resources_result
+        );
+        println!(
+            "Maybe you haven't granted the access to execute the powershell script on this system."
+        );
+        println!("For more details, please execute the `cargo build` command with the `-vv` flag.");
+        std::process::exit(1);
+    }
 
     // witchcraft to get windows.h from the SDK to be able to be found, for the resource compiler
     let target = env::var("TARGET").unwrap();


### PR DESCRIPTION
Add warm notice when failed to execute the `build.rs`.

If we don't set the `-vv` flag when executing `cargo build`, the current command line output will not contain the `child_process` failures, so that we cannot know why the `build process` failed.