### PR TITLE
Fixed non-building without ExecutionPolicy Bypass

### DIFF
--- a/sudo/build.rs
+++ b/sudo/build.rs
@@ -222,6 +222,11 @@ fn main() -> io::Result<()> {
     Command::new("powershell")
         .arg("-NoProfile")
         .arg("-c")
+        .arg("Set-ExecutionPolicy")
+        .arg("Bypass")
+        .arg("-Scope")
+        .arg("Process")
+        .arg("-Force;")
         .arg("..\\.pipelines\\convert-resx-to-rc.ps1")
         .arg("..\\") // Root directory which contains the resx files
         .arg("no_existy.h") // File name of the base resource.h which contains all the non-localized resource definitions


### PR DESCRIPTION
Spent a lot of time trying to figure out why sudo wasn't building - cargo was just spitting out a vague error with no reason for the build to fail. 

As a result, I found out that this is happening because... Running PowerShell scripts is disabled on the system by default. And the error message issued by PowerShell is simply lost somewhere in the PS subroutine call in build.rs.

This change automatically enables scripts to run in the current build session, so the program builds correctly.
