### PR TITLE
docs: remove extraneous word

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Here you can report issues and file feature requests.
 
 ## Relationship to `sudo` on Unix/Linux
 
-Obviously, everything about permissions and the command line experience is
+Everything about permissions and the command line experience is
 different between Windows and Linux. This project is not a fork of the Unix/Linux
 `sudo` project, nor is it a port of that `sudo` project. Instead, Sudo for
 Windows is a Windows-specific implementation of the `sudo` concept.


### PR DESCRIPTION
To many people (including me until recently!) it's not "obvious" that permissions are totally different on these two OSes.

For more general rationale/advice on why avoiding the word "obvious" is important to fostering judgement-free learning, see https://spin.atomicobject.com/never-use-the-word-obviously/