### PR TITLE
Update `windows` crate dependency to 0.57

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,9 +382,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
  "windows-core",
  "windows-targets",
@@ -392,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -404,9 +404,9 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -415,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ embed-manifest = "1.4"
 which = "6.0"
 win_etw_provider = "0.1.8"
 win_etw_macros = "0.1.8"
-windows = "0.56"
+windows = "0.57"
 windows-registry = "0.1"
 winres = "0.1"
 

--- a/sudo/src/elevate_handler.rs
+++ b/sudo/src/elevate_handler.rs
@@ -75,7 +75,7 @@ pub fn spawn_target_for_request(request: &ElevateRequest) -> Result<std::process
 /// * Conditionally attach to the parent process's console (if requested)
 /// * Spawn the target process (with redirected input/output if requested, and with the environment variables passed in if needed)
 /// Called by rust_handle_elevation_request
-pub fn handle_elevation_request(request: &ElevateRequest) -> Result<OwnedHandle> {
+pub fn handle_elevation_request(request: &ElevateRequest) -> Result<Owned<HANDLE>> {
     // Log the request we received to the event log. This should create a pair
     // of events, one for the request, and one for the response, each with the
     // same RequestID.
@@ -135,7 +135,7 @@ pub fn handle_elevation_request(request: &ElevateRequest) -> Result<OwnedHandle>
     // in the COM API to have it limit the handle permissions but that didn't work at all.
     // So now we do it manually here.
     unsafe {
-        let mut child_handle = OwnedHandle::default();
+        let mut child_handle = Owned::default();
         let current_process = GetCurrentProcess();
         DuplicateHandle(
             current_process,

--- a/sudo/src/rpc_bindings_server.rs
+++ b/sudo/src/rpc_bindings_server.rs
@@ -33,7 +33,7 @@ unsafe extern "system" fn rpc_server_callback(
     _interface_uuid: *const c_void,
     context: *const c_void,
 ) -> RPC_STATUS {
-    let mut client_handle = OwnedHandle::default();
+    let mut client_handle = Owned::default();
     let status = I_RpcOpenClientProcess(
         Some(context),
         PROCESS_QUERY_LIMITED_INFORMATION.0,
@@ -80,7 +80,7 @@ fn create_security_descriptor_for_process(pid: u32) -> Result<OwnedSecurityDescr
         {
             let user = {
                 let process =
-                    OwnedHandle::new(OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid)?);
+                    Owned::new(OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid)?);
                 get_sid_for_process(*process)?
             };
 
@@ -227,7 +227,7 @@ pub extern "C" fn server_DoElevationRequest(
 
     match result {
         Ok(mut handle) => {
-            unsafe { child.write(take(&mut handle.0)) };
+            unsafe { child.write(take(&mut handle)) };
             HRESULT::default()
         }
         Err(err) => err.into(),

--- a/sudo/src/run_handler.rs
+++ b/sudo/src/run_handler.rs
@@ -93,9 +93,9 @@ fn adjust_args_for_intrinsics_and_cmdlets(req: &mut ElevateRequest) -> Result<bo
     };
     tracing::trace_log_message(&format!("parent_pid: {parent_pid:?}"));
     // Now, open that process so we can query some more information about it.
-    // (stick it in an OwnedHandle so it gets closed when we're done with it)
+    // (stick it in an `Owned<T>` so it gets closed when we're done with it)
     let parent_process_handle = unsafe {
-        OwnedHandle::new(OpenProcess(
+        Owned::new(OpenProcess(
             PROCESS_QUERY_LIMITED_INFORMATION,
             false,
             parent_pid.try_into().unwrap(),
@@ -417,7 +417,7 @@ fn send_request_via_rpc(req: &ElevateRequest) -> Result<i32> {
     // The GetCurrentProcess() is not a "real" handle and unsuitable to be used with COM.
     // -> We need to clone it first.
     let h_real = unsafe {
-        let mut process = OwnedHandle::default();
+        let mut process = Owned::default();
         let current_process = GetCurrentProcess();
         DuplicateHandle(
             current_process,
@@ -433,7 +433,7 @@ fn send_request_via_rpc(req: &ElevateRequest) -> Result<i32> {
 
     tracing::trace_log_message(&format!("sending i/o/e handles: {:?}", req.handles));
 
-    let mut child_handle = OwnedHandle::default();
+    let mut child_handle = Owned::default();
     let rpc_elevate = rpc_client_do_elevation_request(
         *h_real,
         &req.handles,


### PR DESCRIPTION
As it happens, another update to the `windows` family of crates is available:
https://github.com/microsoft/windows-rs/releases/tag/0.57.0

In particular, this one includes a new feature to support freeing handles automatically:
https://github.com/microsoft/windows-rs/pull/3013

This avoids the need for the `OwnedHandle` helper type in Sudo. 