### PR TITLE
Replace cargo feed with Azure Artifacts feed

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -15,3 +15,8 @@ rustflags = ["-Clink-args=/DEFAULTLIB:rpcrt4.lib"]
 # -Clink-args=/DYNAMICBASE /CETCOMPAT: Enable "shadow stack" (https://learn.microsoft.com/en-us/cpp/build/reference/cetcompat)
 [target.'cfg(all(target_os = "windows", any(target_arch = "x86", target_arch = "x86_64")))']
 rustflags = ["-Clink-args=/DYNAMICBASE /CETCOMPAT"]
+
+[registries]
+Sudo_PublicPackages = { index = "sparse+https://pkgs.dev.azure.com/shine-oss/sudo/_packaging/Sudo_PublicPackages/Cargo/index/" }
+[source.crates-io]
+replace-with = "Sudo_PublicPackages"

--- a/.cargo/ms-toolchain-config.toml
+++ b/.cargo/ms-toolchain-config.toml
@@ -20,6 +20,6 @@ rustflags = ["-Clink-args=/DYNAMICBASE /CETCOMPAT"]
 # Setup the ADO Artifacts feed as a Registry: you'll need to use your own feed in your project that upstreams from crates.io.
 # For more details see https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/azure-artifacts/cargo
 [registries]
-sudo_public_cargo = { index = "sparse+https://pkgs.dev.azure.com/microsoft/Dart/_packaging/sudo_public_cargo/Cargo/index/" }
+Sudo_PublicPackages = { index = "sparse+https://pkgs.dev.azure.com/shine-oss/sudo/_packaging/Sudo_PublicPackages/Cargo/index/" }
 [source.crates-io]
-replace-with = "sudo_public_cargo"
+replace-with = "Sudo_PublicPackages"

--- a/Building.md
+++ b/Building.md
@@ -73,3 +73,16 @@ cargo build --config .cargo\ms-toolchain-config.toml
 ```
 
 Note, if you run that on the public toolchain, you'll most definitely run into ``error: unknown codegen option: `ehcont_guard` `` when building.
+
+### Notes on updating the cargo feed
+
+For internal reasons, we need to maintain a separate Azure Artifacts cargo feed. Largely we just pull dependencies through from crates.io into that feed. Hence the config to replace the default cargo feed with our own.
+
+As a maintainer, if you need to update that feed, then you'll need to do the following:
+
+```cmd
+az login
+az account get-access-token --query "join(' ', ['Bearer', accessToken])" --output tsv | cargo login --registry Sudo_PublicPackages
+```
+
+That'll log you in via the Azure CLI and then log you into the cargo feed. That'll let you pull down the packages but oh yikes everything is awful.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,12 +57,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bitflags"
-version = "2.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
-
-[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,53 +104,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
-name = "either"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
-
-[[package]]
 name = "embed-manifest"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cd446c890d6bed1d8b53acef5f240069ebef91d6fae7c5f52efe61fe8b5eae"
 
 [[package]]
-name = "errno"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
-dependencies = [
- "libc",
- "windows-sys",
-]
-
-[[package]]
-name = "home"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
-
-[[package]]
-name = "once_cell"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "proc-macro2"
@@ -174,19 +131,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rustix"
-version = "0.38.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
-dependencies = [
- "bitflags 2.4.2",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys",
 ]
 
 [[package]]
@@ -223,7 +167,6 @@ dependencies = [
  "clap",
  "embed-manifest",
  "sudo_events",
- "which",
  "win32resources",
  "windows",
  "windows-registry",
@@ -300,19 +243,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fa5e0c10bf77f44aac573e498d1a82d5fbd5e91f6fc0a99e7be4b38e85e101c"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
- "windows-sys",
-]
-
-[[package]]
 name = "widestring"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,7 +272,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e50d0fa665033a19ecefd281b4fb5481eba2972dedbb5ec129c9392a206d652f"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ cc = "1.0"
 # See: https://docs.rs/clap/latest/clap/_features/index.html
 clap = { version = "4.4.7", default-features = false, features = ["std"] }
 embed-manifest = "1.4"
-which = "6.0"
 win_etw_provider = "0.1.8"
 win_etw_macros = "0.1.8"
 windows = "0.57"

--- a/sudo/Cargo.toml
+++ b/sudo/Cargo.toml
@@ -15,12 +15,16 @@ name = "sudo"
 winres.workspace = true
 cc.workspace = true
 embed-manifest.workspace = true
-which = { workspace = true }
+
+[build-dependencies.windows]
+workspace = true
+features = [
+    "Win32_Storage_FileSystem",
+]
 
 [dependencies]
 
 clap = { workspace = true, default-features = false, features = ["color", "help", "usage", "error-context"] }
-which = { workspace = true }
 windows-registry = { workspace = true }
 
 sudo_events = { path = "../sudo_events" }


### PR DESCRIPTION
For ~ compliance reasons ~ we need use an Azure Artifacts feed for our cargo feed. We can't just use it in our internal pipeline either, we need to have the _default_ `.cargo/config.toml` use an artifacts feed too. 🤷

This points our feed at https://dev.azure.com/shine-oss/sudo/_artifacts/feed/Sudo_PublicPackages, which _should_ work publicly now. 

It also removes our dependency on `which`, which Kenny so helpfully pointed out we don't need: https://gist.github.com/kennykerr/a4375597c7507182570576cf9e7b6ae5