### PR TITLE
Replace cargo feed with Azure Artifacts feed

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -15,3 +15,8 @@ rustflags = ["-Clink-args=/DEFAULTLIB:rpcrt4.lib"]
 # -Clink-args=/DYNAMICBASE /CETCOMPAT: Enable "shadow stack" (https://learn.microsoft.com/en-us/cpp/build/reference/cetcompat)
 [target.'cfg(all(target_os = "windows", any(target_arch = "x86", target_arch = "x86_64")))']
 rustflags = ["-Clink-args=/DYNAMICBASE /CETCOMPAT"]
+
+[registries]
+Sudo_PublicPackages = { index = "sparse+https://pkgs.dev.azure.com/shine-oss/sudo/_packaging/Sudo_PublicPackages/Cargo/index/" }
+[source.crates-io]
+replace-with = "Sudo_PublicPackages"

--- a/.cargo/ms-toolchain-config.toml
+++ b/.cargo/ms-toolchain-config.toml
@@ -20,6 +20,6 @@ rustflags = ["-Clink-args=/DYNAMICBASE /CETCOMPAT"]
 # Setup the ADO Artifacts feed as a Registry: you'll need to use your own feed in your project that upstreams from crates.io.
 # For more details see https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/azure-artifacts/cargo
 [registries]
-sudo_public_cargo = { index = "sparse+https://pkgs.dev.azure.com/microsoft/Dart/_packaging/sudo_public_cargo/Cargo/index/" }
+Sudo_PublicPackages = { index = "sparse+https://pkgs.dev.azure.com/shine-oss/sudo/_packaging/Sudo_PublicPackages/Cargo/index/" }
 [source.crates-io]
-replace-with = "sudo_public_cargo"
+replace-with = "Sudo_PublicPackages"


### PR DESCRIPTION
For ~ compliance reasons ~ we need use an Azure Artifacts feed for our cargo feed. We can't just use it in our internal pipeline either, we need to have the _default_ `.cargo/config.toml` use an artifacts feed too. 🤷

This points our feed at https://dev.azure.com/shine-oss/sudo/_artifacts/feed/Sudo_PublicPackages, which _should_ work publicly now.