### PR TITLE
rpc_bindings.rs: Fix `mismatched_lifetime_syntaxes` error

### DIFF
--- a/sudo/src/rpc_bindings.rs
+++ b/sudo/src/rpc_bindings.rs
@@ -13,7 +13,7 @@ pub struct Utf8Str<'a> {
 }
 
 impl<'a> Utf8Str<'a> {
-    pub fn new(s: &str) -> Utf8Str {
+    pub fn new(s: &str) -> Utf8Str<'_> {
         Utf8Str {
             length: min(s.len(), u32::MAX as usize) as u32,
             data: s.as_ptr(),


### PR DESCRIPTION
After Rust 1.89.0 version, [Lifetime elision lint](https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/#mismatched-lifetime-syntaxes-lint) added. This creates `error: hiding a lifetime that's elided elsewhere is confusing` error and requires <'_> for obvious time validation.

```
error: hiding a lifetime that's elided elsewhere is confusing
  --> sudo\src\rpc_bindings.rs:16:19
   |
16 |     pub fn new(s: &str) -> Utf8Str {
   |                   ^^^^     ------- the same lifetime is hidden here
   |                   |
   |                   the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
   = note: `-D mismatched-lifetime-syntaxes` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(mismatched_lifetime_syntaxes)]`
help: use `'_` for type paths
   |
16 |     pub fn new(s: &str) -> Utf8Str<'_> {
   |                                   ++++

error: could not compile `sudo` (bin "sudo") due to 1 previous error
```